### PR TITLE
Use <poll.h> instead of glibc-specific <sys/poll.h>

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -116,7 +116,7 @@
 #else
 #include <termios.h>
 #include <sys/ioctl.h>
-#include <sys/poll.h>
+#include <poll.h>
 #define USE_TERMIOS
 #define HAVE_UNISTD_H
 #endif


### PR DESCRIPTION
This keeps musl happy too

Signed-off-by: Steve Bennett <steveb@workware.net.au>